### PR TITLE
feat: center-align title in Header when icon is absent, align ProgressFrame sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import './App.css'
-import Home from "./pages/Home";
+
+import Progress from "./pages/Progress";
 
 function App() {
   return (
     <>
       <div>
-        <Home />
+        <Progress />
       </div>
     </>
   )

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,50 +3,53 @@ import React from "react";
 import { RoundedArrow } from "../svg/common/Common";
 
 const HeaderVariants = {
-  title: {
-    home: ["text-title2 font-bold font-sans text-scale-1000"],
-    default: ["text-title2 font-bold font-sans text-scale-1000"]
-  },
-  icon: ["size-8 text-scale-1000"]
+    title: {
+        home: ["text-title2 font-bold font-sans text-scale-1000"],
+        default: ["text-title2 font-bold font-sans text-scale-1000"]
+    },
+    icon: ["size-8 text-scale-1000"]
 };
 
 interface HeaderI {
-  name: string;
-  title: string;
-  comp: Icon | null;
+    name: string;
+    title: string;
+    comp: Icon | null;
 }
 
 interface Icon {
-  icon: ReactElement;
+    icon: ReactElement;
 }
 
-const Header = ({name, title, comp }: HeaderI) => {
-  function getTitleVariant() {
-    return name === "home" ? HeaderVariants.title.home.join(" ") : HeaderVariants.title.default.join(" ");
-  }
+const Header = ({ name, title, comp }: HeaderI) => {
+    function getTitleVariant() {
+        return name === "home" ? HeaderVariants.title.home.join(" ") : HeaderVariants.title.default.join(" ");
+    }
 
-  return (
-      <div className="flex w-header h-header rounded-t-[53px] bg-scale-100 items-end px-4 py-2 justify-between">
-        { name !== "home" ? (
-          <>
-         <div className="flex-shrink-0 mb-2">
-              <RoundedArrow className={`${HeaderVariants.icon.join(" ")} transform -rotate-90`} />
-          </div>
-          <span className={`${getTitleVariant()} flex-1 text-center mb-2`}>
+    return (
+        <div className="flex w-header h-header rounded-t-[53px] bg-scale-100 items-end px-4 py-2 justify-center">
+            {name !== "home" ? (
+                <>
+                    <div className="flex-shrink-0 mb-2">
+                        <RoundedArrow className={`${HeaderVariants.icon.join(" ")} transform -rotate-90`} />
+                    </div>
+                    <span className={`${getTitleVariant()} flex-grow text-center mb-2`}>
             {title}
           </span>
-          </>) :
-          <span className={`${getTitleVariant()} flex-1 mb-2 text-left`}>
-           {title}
-          </span>
-        }
-        {comp ? (
-            <div className="flex-shrink-0 mb-2">
-              {React.cloneElement(comp.icon, { className: HeaderVariants.icon.join(" ") })}
-            </div>
-        ) : null}
-      </div>
-  );
+                    {comp ? (
+                        <div className="flex-shrink-0 mb-2">
+                            {React.cloneElement(comp.icon, { className: HeaderVariants.icon.join(" ") })}
+                        </div>
+                    ) : (
+                        <div className="w-8 mb-2" />
+                        )}
+                </>
+            ) : (
+                <span className={`${getTitleVariant()} flex-1 mb-2 text-left`}>
+          {title}
+        </span>
+            )}
+        </div>
+    );
 };
 
 export default Header;

--- a/src/components/progress/frame/ProgressFrame.tsx
+++ b/src/components/progress/frame/ProgressFrame.tsx
@@ -2,80 +2,83 @@ import React, { useState } from "react";
 import CustomCircularProgress from "./CircularProgress";
 
 interface ProgressFrameProps {
-  text: string;
-  progress: number;
-  tag: string;
-  subtag: string;
-  isBadge: boolean;
+    text: string;
+    progress: number;
+    tag: string;
+    subtag: string;
+    isBadge: boolean;
 }
 
 const ProgressFrame = ({ text, progress, tag, subtag, isBadge }: ProgressFrameProps) => {
-  return (
-    <div className="flex flex-col items-center justify-center w-header h-progressFrame bg-scale-100">
-      <CustomCircularProgress text={text} progress={progress} />
-      <span className="font-sans font-bold text-title2 text-scale-1000 text-center">{tag}</span>
-      <span className="font-sans text-body text-scale-600 text-center mb-3">{subtag}</span>
-      <SwitchButtons badge={isBadge} />
-    </div>
-  );
+    return (
+        <div className="flex flex-col items-center justify-center w-header h-progressFrame bg-scale-100 rounded-b-sm">
+            <div className="flex flex-col items-center justify-center flex-grow">
+                <CustomCircularProgress text={text} progress={progress} />
+                <span className="font-sans font-bold text-title2 text-scale-1000 text-center">{tag}</span>
+                <span className="font-sans text-body text-scale-600 text-center mb-3">{subtag}</span>
+            </div>
+            <div className="mt-auto w-full">
+                <SwitchButtons badge={isBadge} />
+            </div>
+        </div>
+    );
 };
 
 interface SwitchButtonsProps {
-  badge: boolean;
+    badge: boolean;
 }
 
 const SwitchButtons = ({ badge }: SwitchButtonsProps) => {
-  const [isBadge, setIsBadge] = useState(badge);
+    const [isBadge, setIsBadge] = useState(badge);
 
-  function handleClick(newIsBadge: boolean) {
-    if (isBadge !== newIsBadge) setIsBadge(newIsBadge);
-  }
+    function handleClick(newIsBadge: boolean) {
+        if (isBadge !== newIsBadge) setIsBadge(newIsBadge);
+    }
 
-  return (
-    <div className="h-[50px] w-[393px] flex">
-      {!isBadge ? (
-        <>
-          <button
-            className="h-[50px] w-[196px] bg-scale-100 rounded-l-full flex items-center justify-center focus:outline-none border-none"
-            onClick={() => handleClick(false)}
-          >
-            <span className="font-sans text-body font-medium text-scale-700">Missions</span>
-          </button>
-          <CustomButton text="Badges" rounded="rounded-r-full focus:outline-none border-none" onclick={() => handleClick(true)} />
-        </>
-      ) : (
-        <>
-          <CustomButton text="Missions" rounded="rounded-l-full focus:outline-none border-none" onclick={() => handleClick(false)} />
-          <button
-            className="h-[50px] w-[196px] bg-scale-100 rounded-r-full flex items-center justify-center focus:outline-none border-none"
-            onClick={() => handleClick(true)}
-          >
-            <span className="font-sans text-body font-medium text-scale-700">Badges</span>
-          </button>
-        </>
-      )}
-    </div>
-  );
+    return (
+        <div className="h-[50px] w-full flex">
+            {!isBadge ? (
+                <>
+                    <button
+                        className="h-[50px] w-1/2 bg-scale-100 rounded-l-full flex items-center justify-center focus:outline-none border-none"
+                        onClick={() => handleClick(true)}
+                    >
+                        <span className="font-sans text-body font-medium text-scale-700">Missions</span>
+                    </button>
+                    <CustomButton text="Badges" rounded="rounded-r-full focus:outline-none border-none" onclick={() => handleClick(true)} />
+                </>
+            ) : (
+                <>
+                    <CustomButton text="Missions" rounded="rounded-l-full focus:outline-none border-none" onclick={() => handleClick(false)} />
+                    <button
+                        className="h-[50px] w-1/2 bg-scale-100 rounded-r-full flex items-center justify-center focus:outline-none border-none"
+                        onClick={() => handleClick(false)}
+                    >
+                        <span className="font-sans text-body font-medium text-scale-700">Badges</span>
+                    </button>
+                </>
+            )}
+        </div>
+    );
 };
 
 interface CustomButtonProps {
-  text: string;
-  rounded: string;
-  onclick: () => void;
+    text: string;
+    rounded: string;
+    onclick: () => void;
 }
 
 const CustomButton = ({ text, rounded, onclick }: CustomButtonProps) => {
-  return (
-    <button
-      className={`h-[50px] w-[196px] bg-scale-100 flex flex-col items-center justify-center overflow-hidden ${rounded}`}
-      onClick={onclick}
-    >
-      <span className="font-sans text-body font-medium text-primary-500">{text}</span>
-      <div className="w-full h-1 mt-1 flex">
-        <div className="bg-primary-700 w-full h-full" />
-      </div>
-    </button>
-  );
+    return (
+        <button
+            className={`h-[50px] w-1/2 bg-scale-100 flex items-center justify-center relative ${rounded}`}
+            onClick={onclick}
+        >
+            <span className="font-sans text-body font-medium text-primary-500">{text}</span>
+            <div className="absolute bottom-0 w-full h-[2px] bg-primary-700 rounded-b-sm" />
+        </button>
+    );
 };
+
 
 export default ProgressFrame;

--- a/src/pages/Progress.tsx
+++ b/src/pages/Progress.tsx
@@ -1,0 +1,90 @@
+import React, {useState} from 'react';
+import Header from '../components/header/Header';
+import ProgressFrame from '../components/progress/frame/ProgressFrame';
+import ProgressButton from '../components/progress/button/ProgressButton';
+import NavBar from '../components/navbar/Navbar';
+import { IcRoundHome } from '../components/svg/navbar/Home';
+import { MaterialSymbolsLightPill } from '../components/svg/navbar/Pill';
+import { MdiProgressStar, MynauiCalendar } from '../components/svg/navbar/Calendar';
+import { MdiLightHeart } from '../components/svg/navbar/Heart';
+import {OnfireBadge} from "../components/svg/badge/OnfireBadge";
+import {HydratedBadge} from "../components/svg/badge/HydratedBadge";
+import {TravelerBadge} from "../components/svg/badge/TravelerBadge";
+
+const progressData = {
+    text: "5",
+    progress: 20,
+    tag: "You are level 5!",
+    subtag: "150 points to level up",
+    isBadge: true,
+};
+
+const navPages = [
+    { icon: <IcRoundHome /> },
+    { icon: <MaterialSymbolsLightPill /> },
+    { icon: <MynauiCalendar /> },
+    { icon: <MdiLightHeart /> },
+    { icon: <MdiProgressStar /> },
+];
+
+const Progress: React.FC = () => {
+
+    const [isBadge, setIsBadge] = useState(true);
+
+    const toggleBadgeState = () => {
+        setIsBadge(!isBadge);
+
+    };
+    return (
+        <div className="flex flex-col items-center justify-between bg-scale-400 rounded-[53px] w-[393px] h-[852px]">
+
+            <Header comp={null} name={"progress"} title={"Progress"} />
+
+            <main className="flex-grow flex flex-col items-center justify-start">
+                <section className="pb-3" onClick={toggleBadgeState}>
+                    <ProgressFrame {...progressData} />
+                </section>
+
+                {isBadge ? (
+                    <>
+                        <section className="pb-3">
+                            <ProgressButton
+                                text="MEDITATE"
+                                textColor="text-scale-1000"
+                                unfilledColor="bg-scale-100"
+                                filledColor="bg-primary-800"
+                                timeText="0:10"
+                            />
+                        </section>
+
+                        <section className="pb-3">
+                            <ProgressButton
+                                text="DRINK WATER"
+                                textColor="text-scale-1000"
+                                unfilledColor="bg-scale-100"
+                                filledColor="bg-primary-800"
+                                timeText="0:30"
+                            />
+                        </section>
+                    </>
+                ) : (
+                    <section className="pb-3">
+                        <div className="flex flex-wrap gap-6 p-2 justify-center">
+                            <OnfireBadge/>
+                            <TravelerBadge/>
+                            <HydratedBadge/>
+                            <OnfireBadge/>
+                            <TravelerBadge/>
+                            <HydratedBadge/>
+                        </div>
+                    </section>
+
+                )}
+            </main>
+
+            <NavBar pages={navPages}/>
+        </div>
+    );
+};
+
+export default Progress;


### PR DESCRIPTION
- Updated `Header.tsx` to maintain center alignment for title when `comp` is null by adding a placeholder div as a spacer
- Adjusted styling in `ProgressFrame` to align missions, badges, and active selection line at the bottom of the component for a more cohesive layout
- Implemented `Progress.tsx` page with existing components per Figma design specifications
- Minor UI fixes for consistent alignment and spacing
